### PR TITLE
issue #4, relationships test and validation_errors alias

### DIFF
--- a/dbt/include/oracle/macros/schema_tests.sql
+++ b/dbt/include/oracle/macros/schema_tests.sql
@@ -31,7 +31,7 @@ validation_errors as (
     )
 )
 
-select count(*)
+select count(*) as validation_errors
 from validation_errors
 
 {% endmacro %}
@@ -42,8 +42,21 @@ from validation_errors
 
 {% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
 
-select count(*)
+select count(*) as validation_errors
 from {{ model.include(False, True, True) }}
 where {{ column_name }} is null
 
+{% endmacro %}
+
+{% macro oracle__test_relationships(model, to, field) %}
+  {% set column_name = kwargs.get('column_name', kwargs.get('from')) %}
+  select count(*) as validation_errors
+  from (
+      select {{ column_name }} as id from {{ model.include(False, True, True) }}
+  ) child
+  left join (
+      select {{ field }} as id from {{ to.include(False, True, True) }}
+  ) parent on parent.id = child.id
+  where child.id is not null
+    and parent.id is null
 {% endmacro %}


### PR DESCRIPTION
Hi @dpavancini,

reading [Use adapter macro pattern for core schema tests #2415](https://github.com/fishtown-analytics/dbt/issues/2415),
it seems this pull request will have to wait until schema test macros are migrated to the adapter macro pattern.

Are you sure the accepted_values and not_null implementations are really used by dbt ?
I inserted a log statement, and did not see any output, so I ask the question, just in case.

This is my really first PR on github, so I beg your pardon if I do not follow the standard way.
I did not find a way to link it to the related issue [#4 ](https://github.com/techindicium/dbt-oracle/issues/4)

Best,
Fabrice