### PR TITLE
issue #8, quoting policy not being applied in the adapter's macros

### DIFF
--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -35,7 +35,7 @@
      dne_942    EXCEPTION;
      PRAGMA EXCEPTION_INIT(dne_942, -942);
   BEGIN
-     EXECUTE IMMEDIATE 'DROP {{ relation.type }} {{ relation }} cascade constraint';
+     EXECUTE IMMEDIATE 'DROP {{ relation.type }} {{ relation | replace('"', '') }} cascade constraint';
   EXCEPTION
      WHEN dne_942 THEN
         NULL; -- if it doesn't exist, do nothing .. no error, nothing .. ignore.


### PR DESCRIPTION
A possible workaround for [Running with different materilizations leaves dirty objects #8](https://github.com/techindicium/dbt-oracle/issues/8). If we could assert the drop_relation macro is never called on inexisting objects, the exception handling could be removed, and one could see when it truly fails.

Best,