### PR TITLE
reworked PR containing all commits

### DIFF
--- a/dbt/adapters/oracle/impl.py
+++ b/dbt/adapters/oracle/impl.py
@@ -20,7 +20,11 @@ class OracleAdapter(SQLAdapter):
         lens = (len(d.encode("utf-8")) for d in column.values_without_nulls())
         max_len = max(lens) if lens else 64
         length = max_len if max_len > 16 else 16
-        return "varchar({})".format(length)
+        return "varchar2({})".format(length)
+
+    @classmethod
+    def convert_date_type(cls, agate_table, col_idx):
+        return "timestamp"
 
     @classmethod
     def convert_datetime_type(cls, agate_table, col_idx):

--- a/dbt/adapters/oracle/impl.py
+++ b/dbt/adapters/oracle/impl.py
@@ -1,4 +1,5 @@
 from dbt.adapters.sql import SQLAdapter
+from dbt.adapters.base.meta import available
 from dbt.adapters.oracle import OracleAdapterConnectionManager
 from dbt.adapters.oracle.relation import OracleRelation
 
@@ -14,6 +15,40 @@ class OracleAdapter(SQLAdapter):
         return 'CURRENT_DATE'
 
     @classmethod
+    def convert_text_type(cls, agate_table, col_idx):
+        column = agate_table.columns[col_idx]
+        lens = (len(d.encode("utf-8")) for d in column.values_without_nulls())
+        max_len = max(lens) if lens else 64
+        length = max_len if max_len > 16 else 16
+        return "varchar({})".format(length)
+
+    @classmethod
+    def convert_datetime_type(cls, agate_table, col_idx):
+        return "timestamp"
+
+    @classmethod
+    def convert_boolean_type(cls, agate_table, col_idx):
+        return "number(1)"
+
+    @classmethod
     def convert_number_type(cls, agate_table, col_idx):
         decimals = agate_table.aggregate(agate.MaxPrecision(col_idx))
-        return "float" if decimals else "int"
+        return "number"
+
+    @classmethod
+    def convert_time_type(cls, agate_table, col_idx):
+        return "timestamp"
+
+    @available
+    def verify_database(self, database):
+        if database.startswith('"'):
+            database = database.strip('"')
+        expected = self.config.credentials.database
+        if database.lower() != expected.lower():
+            raise dbt.exceptions.NotImplementedException(
+                'Cross-db references not allowed in {} ({} vs {})'
+                .format(self.type(), database, expected)
+            )
+        # return an empty string on success so macros can call this
+        return ''
+

--- a/dbt/include/oracle/dbt_project.yml
+++ b/dbt/include/oracle/dbt_project.yml
@@ -2,4 +2,9 @@
 name: dbt_oracle
 version: 1.0
 
+quoting:
+  database: false
+  schema: false
+  identifier: false
+
 macro-paths: ["macros"]

--- a/dbt/include/oracle/dbt_project.yml
+++ b/dbt/include/oracle/dbt_project.yml
@@ -1,5 +1,6 @@
 
 name: dbt_oracle
+config-version: 2
 version: 1.0
 
 quoting:

--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -1,32 +1,162 @@
-{% macro oracle__list_schemas(database) %}
-    {% call statement('list_schemas', fetch_result=True, auto_begin=False) -%}
-       	select username as schema_name
-        from sys.all_users
-        order by username
+{% macro oracle__get_columns_in_query(select_sql) %}
+    {% call statement('get_columns_in_query', fetch_result=True, auto_begin=False) -%}
+        select * from (
+            {{ select_sql }}
+        ) __dbt_sbq
+        where 1 = 0 and rownum < 1
     {% endcall %}
-    {{ return(load_result('list_schemas').table) }}
+
+    {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | lower | list) }}
 {% endmacro %}
 
 {% macro oracle__create_schema(database_name, schema_name) -%}
-  {% call statement('create_schema') -%}
-    select 1 from dual -- just trying to do nothing for now
-  {% endcall %}
+  {% set typename = adapter.type() %}
+  {% set msg -%}
+    create_schema not implemented for {{ typename }}
+  {%- endset %}
+
+  {{ exceptions.raise_compiler_error(msg) }}
 {% endmacro %}
 
+{% macro oracle__drop_schema(database_name, schema_name) -%}
+  {% set typename = adapter.type() %}
+  {% set msg -%}
+    drop_schema  not implemented for {{ typename }}
+  {%- endset %}
 
-{% macro oracle__list_relations_without_caching(information_schema, schema) %}
-  {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    SELECT 
-      '{{ database }}' as database,
-      lower(object_name),
-      lower(owner),
-      lower(object_type) as table_type
-    FROM
-      all_objects 
-    where
-      OWNER = (SELECT USER FROM dual)
+  {{ exceptions.raise_compiler_error(msg) }}
+{% endmacro %}
+
+{% macro oracle__create_table_as(temporary, relation, sql) -%}
+  {%- set sql_header = config.get('sql_header', none) -%}
+
+  {{ sql_header if sql_header is not none }}
+
+  create {% if temporary -%}
+    temporary
+  {%- endif %} table {{ relation.include(schema=(not temporary)).quote(schema=False, identifier=False) }}
+  as 
+    {{ sql }}
+  
+{%- endmacro %}
+
+{% macro oracle__create_view_as(relation, sql) -%}
+  {%- set sql_header = config.get('sql_header', none) -%}
+
+  {{ sql_header if sql_header is not none }}
+  create view {{ relation.quote(schema=False, identifier=False)  }} as 
+    {{ sql }}
+  
+{% endmacro %}
+
+{% macro oracle__get_columns_in_relation(relation) -%}
+  {% call statement('get_columns_in_relation', fetch_result=True) %}
+      with columns as (
+        select
+            SYS_CONTEXT('userenv', 'DB_NAME') table_catalog,
+            owner table_schema,
+            table_name,
+            column_name,
+            data_type,
+            data_type_mod,
+            decode(data_type_owner, null, TO_CHAR(null), SYS_CONTEXT('userenv', 'DB_NAME')) domain_catalog,
+            data_type_owner domain_schema,
+            data_length character_maximum_length,
+            data_length character_octet_length,
+            data_length,
+            data_precision numeric_precision,
+            data_scale numeric_scale,
+            nullable is_nullable,
+            column_id ordinal_position,
+            default_length,
+            data_default column_default,
+            num_distinct,
+            low_value,
+            high_value,
+            density,
+            num_nulls,
+            num_buckets,
+            last_analyzed,
+            sample_size,
+            SYS_CONTEXT('userenv', 'DB_NAME') character_set_catalog,
+            'SYS' character_set_schema,
+            SYS_CONTEXT('userenv', 'DB_NAME') collation_catalog,
+            'SYS' collation_schema,
+            character_set_name,
+            char_col_decl_length,
+            global_stats,
+            user_stats,
+            avg_col_len,
+            char_length,
+            char_used,
+            v80_fmt_image,
+            data_upgraded,
+            histogram
+          from sys.all_tab_columns
+      )
+      select
+          lower(column_name) as "name",
+          lower(data_type) as "type",
+          char_length as "character_maximum_length",
+          numeric_precision as "numeric_precision",
+          numeric_scale as "numeric_scale"
+      from columns
+      where table_name = upper('{{ relation.identifier }}')
+        {% if relation.schema %}
+        and table_schema = upper('{{ relation.schema }}')
+        {% endif %}
+        {% if relation.database %}
+        and table_catalog = upper('{{ relation.database }}')
+        {% endif %}
+      order by ordinal_position
+
   {% endcall %}
-  {{ return(load_result('list_relations_without_caching').table) }}
+  {% set table = load_result('get_columns_in_relation').table %}
+  {{ return(sql_convert_columns_in_relation(table)) }}
+{% endmacro %}
+
+{% macro oracle_escape_comment(comment) -%}
+  {% if comment is not string %}
+    {% do exceptions.raise_compiler_error('cannot escape a non-string: ' ~ comment) %}
+  {% endif %}
+  {%- set start_quote = "'q{" -%}
+  {%- set end_quote = "}'" -%}
+  {%- if end_quote in comment -%}
+    {%- do exceptions.raise_compiler_error('The string ' ~ end_quote ~ ' is not allowed in comments.') -%}
+  {%- endif -%}
+  {{ start_quote }}{{ comment }}{{ end_quote }}
+{%- endmacro %}
+
+{% macro oracle__alter_relation_comment(relation, comment) %}
+  {% set escaped_comment = oracle_escape_comment(comment) %}
+  {# "comment on table" even for views #}
+  comment on table {{ relation.quote(schema=False, identifier=False) }} is {{ escaped_comment }}
+{% endmacro %}
+
+{% macro oracle__alter_column_comment(relation, column_dict) %}
+  {% for column_name in column_dict %}
+    {% set comment = column_dict[column_name]['description'] %}
+    {% set escaped_comment = oracle_escape_comment(comment) %}
+    comment on column {{ relation.quote(schema=False, identifier=False) }}.{{ column_name }} is {{ escaped_comment }}
+  {% endfor %}
+{% endmacro %}
+
+{% macro oracle__alter_column_type(relation, column_name, new_column_type) -%}
+  {#
+    1. Create a new column (w/ temp name and correct type)
+    2. Copy data over to it
+    3. Drop the existing column (cascade!)
+    4. Rename the new column to existing column
+  #}
+  {%- set tmp_column = column_name + "__dbt_alter" -%}
+
+  {% call statement('alter_column_type') %}
+    alter table {{ relation.quote(schema=False, identifier=False) }} add column {{ adapter.quote(tmp_column) }} {{ new_column_type }};
+    update {{ relation.quote(schema=False, identifier=False)  }} set {{ adapter.quote(tmp_column) }} = {{ adapter.quote(column_name) }};
+    alter table {{ relation.quote(schema=False, identifier=False) }} drop column {{ adapter.quote(column_name) }} cascade;
+    rename column {{ relation.quote(schema=False, identifier=False) }}.{{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }}
+  {% endcall %}
+
 {% endmacro %}
 
 {% macro oracle__drop_relation(relation) -%}
@@ -35,7 +165,7 @@
      dne_942    EXCEPTION;
      PRAGMA EXCEPTION_INIT(dne_942, -942);
   BEGIN
-     EXECUTE IMMEDIATE 'DROP {{ relation.type }} {{ relation }} cascade constraint';
+     EXECUTE IMMEDIATE 'DROP {{ relation.type }} {{ relation.quote(schema=False, identifier=False) }} cascade constraint';
   EXCEPTION
      WHEN dne_942 THEN
         NULL; -- if it doesn't exist, do nothing .. no error, nothing .. ignore.
@@ -43,52 +173,83 @@
   {%- endcall %}
 {% endmacro %}
 
-{% macro oracle__create_table_as(temporary, relation, sql) -%}
-  {%- set sql_header = config.get('sql_header', none) -%}
-
-  {{ sql_header if sql_header is not none }}
-
-  create {% if temporary: -%}temporary{%- endif %} table
-    {{ relation.include(database=False, schema=(not temporary)) }}
-  as 
-    {{ sql }}
-  
-{% endmacro %}
-
-
-{% macro oracle__rename_relation(from_relation, to_relation) -%}
-  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}
-  {% call statement('rename_relation') -%}
-    rename {{ from_relation.include(False, False, True) }} to {{ target_name }}
-  {%- endcall %}
-{% endmacro %}
-
-{% macro oracle__get_columns_in_relation(relation) -%}
-  {% call statement('get_columns_in_relation', fetch_result=True) %}
-      select 
-		  col.column_name,
-          col.data_type, 
-          col.data_length, 
-          col.data_precision, 
-          col.data_scale
-      from sys.all_tab_columns col
-      WHERE col.table_name = 'TABLE_RELATION'
-      AND col.owner = (SELECT USER FROM dual)
-      order by col.column_id
-  {% endcall %}
-  {% set table = load_result('get_columns_in_relation').table %}
-  {{ return(sql_convert_columns_in_relation(table)) }}
-{% endmacro %}
-
 {% macro oracle__truncate_relation(relation) -%}
   {% call statement('truncate_relation') -%}
-    truncate table {{ relation | replace('"', "")  }}
+    truncate table {{ relation.quote(schema=False, identifier=False) }}
   {%- endcall %}
 {% endmacro %}
 
-{% macro oracle__create_view_as(relation, sql) -%}
-  {%- set sql_header = config.get('sql_header', none) -%}
-  {{ sql_header if sql_header is not none }}
-  create view {{ relation.render() }} as
-  {{ sql | replace(""+database+".", "")}}
+{% macro oracle__rename_relation(from_relation, to_relation) -%}
+  {% call statement('rename_relation') -%}
+    rename {{ from_relation.include(False, False, True).quote(schema=False, identifier=False) }} to {{ to_relation.include(False, False, True).quote(schema=False, identifier=False) }}
+  {%- endcall %}
 {% endmacro %}
+
+{% macro oracle__information_schema_name(database) -%}
+  {% if database -%}
+    {{ adapter.verify_database(database) }}
+  {%- endif -%}
+  sys
+{%- endmacro %}
+
+{% macro oracle__list_schemas(database) %}
+  {% if database -%}
+    {{ adapter.verify_database(database) }}
+  {%- endif -%}
+  {% call statement('list_schemas', fetch_result=True, auto_begin=False) -%}
+     	select lower(username) as "name"
+      from sys.all_users
+      order by username
+  {% endcall %}
+  {{ return(load_result('list_schemas').table) }}
+{% endmacro %}
+
+{% macro oracle__check_schema_exists(information_schema, schema) -%}
+  {% if information_schema.database -%}
+    {{ adapter.verify_database(information_schema.database) }}
+  {%- endif -%}
+  {% call statement('check_schema_exists', fetch_result=True, auto_begin=False) %}
+    select count(*) from sys.all_users where username = upper('{{ schema }}')
+  {% endcall %}
+  {{ return(load_result('check_schema_exists').table) }}
+{% endmacro %}
+
+{% macro oracle__list_relations_without_caching(schema_relation) %}
+  {% call statement('list_relations_without_caching', fetch_result=True) -%}
+    with tables as
+      (select SYS_CONTEXT('userenv', 'DB_NAME') table_catalog,
+         owner table_schema,
+         table_name,
+         case
+           when iot_type = 'Y'
+           then 'IOT'
+           when temporary = 'Y'
+           then 'TEMP'
+           else 'BASE TABLE'
+         end table_type
+       from sys.all_tables
+       union all
+       select SYS_CONTEXT('userenv', 'DB_NAME'),
+         owner,
+         view_name,
+         'VIEW'
+       from sys.all_views
+  )
+  select lower(table_catalog) as "database_name"
+    ,lower(table_name) as "name"
+    ,lower(table_schema) as "schema_name"
+    ,case table_type
+      when 'BASE TABLE' then 'table'
+      when 'VIEW' then 'view'
+    end as "kind"
+  from tables
+  where table_type in ('BASE TABLE', 'VIEW')
+    and table_catalog = upper('{{ schema_relation.database }}')
+    and table_schema = upper('{{ schema_relation.schema }}')
+  {% endcall %}
+  {{ return(load_result('list_relations_without_caching').table) }}
+{% endmacro %}
+
+{% macro oracle__current_timestamp() -%}
+  CURRENT_DATE
+{%- endmacro %}

--- a/dbt/include/oracle/macros/catalog.sql
+++ b/dbt/include/oracle/macros/catalog.sql
@@ -71,18 +71,18 @@
                  from sys.all_views
           )
           select
-              tables.table_catalog as "table_database",
-              tables.table_schema as "table_schema",
-              tables.table_name as "table_name",
-              tables.table_type as "table_type",
+              lower(tables.table_catalog) as "table_database",
+              lower(tables.table_schema) as "table_schema",
+              lower(tables.table_name) as "table_name",
+              lower(tables.table_type) as "table_type",
               all_tab_comments.comments as "table_comment",
-              columns.column_name as "column_name",
+              lower(columns.column_name) as "column_name",
               ordinal_position as "column_index",
-              case
+              lower(case
                 when data_type like '%CHAR%'
                 then data_type || '(' || cast(char_length as varchar(10)) || ')'
                 else data_type
-              end as "column_type",
+              end) as "column_type",
               all_col_comments.comments as "column_comment",
               tables.table_schema as "table_owner"
           from tables

--- a/dbt/include/oracle/macros/catalog.sql
+++ b/dbt/include/oracle/macros/catalog.sql
@@ -1,0 +1,112 @@
+{% macro oracle__get_catalog(information_schema, schemas) -%}
+
+  {%- call statement('catalog', fetch_result=True) -%}
+    {#
+      If the user has multiple databases set and the first one is wrong, this will fail.
+      But we won't fail in the case where there are multiple quoting-difference-only dbs, which is better.
+    #}
+    {% set database = information_schema.database %}
+    {{ adapter.verify_database(database) }}
+
+    with columns as (
+            select
+                SYS_CONTEXT('userenv', 'DB_NAME') table_catalog,
+                owner table_schema,
+                table_name,
+                column_name,
+                data_type,
+                data_type_mod,
+                decode(data_type_owner, null, TO_CHAR(null), SYS_CONTEXT('userenv', 'DB_NAME')) domain_catalog,
+                data_type_owner domain_schema,
+                data_length character_maximum_length,
+                data_length character_octet_length,
+                data_length,
+                data_precision numeric_precision,
+                data_scale numeric_scale,
+                nullable is_nullable,
+                column_id ordinal_position,
+                default_length,
+                data_default column_default,
+                num_distinct,
+                low_value,
+                high_value,
+                density,
+                num_nulls,
+                num_buckets,
+                last_analyzed,
+                sample_size,
+                SYS_CONTEXT('userenv', 'DB_NAME') character_set_catalog,
+                'SYS' character_set_schema,
+                SYS_CONTEXT('userenv', 'DB_NAME') collation_catalog,
+                'SYS' collation_schema,
+                character_set_name,
+                char_col_decl_length,
+                global_stats,
+                user_stats,
+                avg_col_len,
+                char_length,
+                char_used,
+                v80_fmt_image,
+                data_upgraded,
+                histogram
+              from sys.all_tab_columns
+          ),
+          tables as
+                (select SYS_CONTEXT('userenv', 'DB_NAME') table_catalog,
+                   owner table_schema,
+                   table_name,
+                   case
+                     when iot_type = 'Y'
+                     then 'IOT'
+                     when temporary = 'Y'
+                     then 'TEMP'
+                     else 'BASE TABLE'
+                   end table_type
+                 from sys.all_tables
+                 union all
+                 select SYS_CONTEXT('userenv', 'DB_NAME'),
+                   owner,
+                   view_name,
+                   'VIEW'
+                 from sys.all_views
+          )
+          select
+              tables.table_catalog as "table_database",
+              tables.table_schema as "table_schema",
+              tables.table_name as "table_name",
+              tables.table_type as "table_type",
+              all_tab_comments.comments as "table_comment",
+              columns.column_name as "column_name",
+              ordinal_position as "column_index",
+              case
+                when data_type like '%CHAR%'
+                then data_type || '(' || cast(char_length as varchar(10)) || ')'
+                else data_type
+              end as "column_type",
+              all_col_comments.comments as "column_comment",
+              tables.table_schema as "table_owner"
+          from tables
+          inner join columns on columns.table_catalog = tables.table_catalog
+            and columns.table_schema = tables.table_schema
+            and columns.table_name = tables.table_name
+          left join all_tab_comments
+            on all_tab_comments.owner = tables.table_schema
+              and all_tab_comments.table_name = tables.table_name
+          left join all_col_comments
+            on all_col_comments.owner = columns.table_schema
+              and all_col_comments.table_name = columns.table_name
+              and all_col_comments.column_name = columns.column_name
+          where (
+              {%- for schema in schemas -%}
+                tables.table_schema = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}
+              {%- endfor -%}
+            )
+          order by
+              tables.table_schema,
+              tables.table_name,
+              ordinal_position
+  {%- endcall -%}
+
+  {{ return(load_result('catalog').table) }}
+
+{%- endmacro %}

--- a/dbt/include/oracle/macros/materializations/incremental/helpers.sql
+++ b/dbt/include/oracle/macros/materializations/incremental/helpers.sql
@@ -1,0 +1,51 @@
+
+{% macro oracle_incremental_upsert_backup(tmp_relation, target_relation, unique_key=none, statement_name="main") %}
+    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+    {%- set dest_cols_csv = dest_columns | map(attribute='name') | join(', ') -%}
+
+    {%- if unique_key is not none -%}
+    delete
+    from {{ target_relation }}
+    where ({{ unique_key }}) in (
+        select ({{ unique_key }})
+        from {{ tmp_relation }}
+    );
+    {%- endif %}
+
+    insert into {{ target_relation }} ({{ dest_cols_csv }})
+    (
+       select {{ dest_cols_csv }}
+       from {{ tmp_relation }}
+    )
+{%- endmacro %}
+
+{% macro oracle_incremental_upsert(tmp_relation, target_relation, unique_key=none, statement_name="main") %}
+    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+    {%- set dest_cols_csv = dest_columns | map(attribute='name') | join(', ') -%}
+
+    {%- if unique_key is not none -%}
+    merge into {{ target_relation }} target
+      using {{ tmp_relation }} temp
+      on (temp.{{ unique_key }} = target.{{ unique_key }})
+    when matched then
+      update set
+      {% for col in dest_columns if col.name != unique_key %}
+        target.{{ col.name }} = temp.{{ col.name }}
+        {% if not loop.last %}, {% endif %}
+      {% endfor %}
+    when not matched then
+      insert( {{ dest_cols_csv }} )
+      values(
+        {% for col in dest_columns %}
+          temp.{{ col.name }}
+          {% if not loop.last %}, {% endif %}
+        {% endfor %}
+      )
+    {%- else %}
+    insert into {{ target_relation }} ({{ dest_cols_csv }})
+    (
+       select {{ dest_cols_csv }}
+       from {{ tmp_relation }}
+    )
+    {% endif %}
+{%- endmacro %}

--- a/dbt/include/oracle/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/oracle/macros/materializations/incremental/incremental.sql
@@ -1,0 +1,57 @@
+
+{% materialization incremental, adapter='oracle' -%}
+
+  {% set unique_key = config.get('unique_key') %}
+  {% set full_refresh_mode = flags.FULL_REFRESH %}
+
+  {% set target_relation = this.incorporate(type='table') %}
+  {% set existing_relation = load_relation(this) %}
+  {% set tmp_relation = make_temp_relation(this) %}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% set to_drop = [] %}
+  {% if existing_relation is none %}
+      {% set build_sql = create_table_as(False, target_relation, sql) %}
+  {% elif existing_relation.is_view or full_refresh_mode %}
+      {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}
+      {% set backup_identifier = existing_relation.identifier ~ "__dbt_backup" %}
+      {% set backup_relation = existing_relation.incorporate(path={"identifier": backup_identifier}) %}
+      {% do adapter.drop_relation(backup_relation) %}
+
+      {% do adapter.rename_relation(target_relation, backup_relation) %}
+      {% set build_sql = create_table_as(False, target_relation, sql) %}
+      {% do to_drop.append(backup_relation) %}
+  {% else %}
+      {% set tmp_relation = make_temp_relation(target_relation) %}
+      {% do to_drop.append(tmp_relation) %}
+      {% do run_query(create_table_as(True, tmp_relation, sql)) %}
+      {% do adapter.expand_target_column_types(
+             from_relation=tmp_relation,
+             to_relation=target_relation) %}
+      {% set build_sql = oracle_incremental_upsert(tmp_relation, target_relation, unique_key=unique_key) %}
+  {% endif %}
+
+  {% call statement("main") %}
+      {{ build_sql }}
+  {% endcall %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  -- `COMMIT` happens here
+  {% do adapter.commit() %}
+
+  {% for rel in to_drop %}
+      {% do adapter.drop_relation(rel) %}
+  {% endfor %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{%- endmaterialization %}

--- a/dbt/include/oracle/macros/materializations/seed/seed.sql
+++ b/dbt/include/oracle/macros/materializations/seed/seed.sql
@@ -15,12 +15,12 @@
         {% set sql %}
             insert all
             {% for row in chunk -%}
-              into {{ this.render() }} ({{ cols_sql }}) values
-                ( {%- for column in agate_table.column_names -%}
+              into {{ this.render() }} ({{ cols_sql }}) values(
+                {%- for column in agate_table.column_names -%}
                     :p{{ loop.index }} 
                     {%- if not loop.last%},{%- endif %}
-                {%- endfor %} )
-            {%- endfor %}
+                {%- endfor %})
+            {% endfor %}
             select * from dual
         {% endset %}
 

--- a/dbt/include/oracle/macros/materializations/seed/seed.sql
+++ b/dbt/include/oracle/macros/materializations/seed/seed.sql
@@ -36,6 +36,6 @@
 {% endmacro %}
 
 {% macro oracle__load_csv_rows(model, agate_table) %}
-  {{ return(oracle_basic_load_csv_rows(model, 50, agate_table) )}}
+  {{ return(oracle_basic_load_csv_rows(model, 100, agate_table) )}}
 {% endmacro %}
 

--- a/dbt/include/oracle/macros/materializations/seed/seed.sql
+++ b/dbt/include/oracle/macros/materializations/seed/seed.sql
@@ -1,4 +1,5 @@
-{% macro basic_load_csv_rows_oracle(model, batch_size, agate_table) %}
+{% macro oracle_basic_load_csv_rows(model, batch_size, agate_table) %}
+
     {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}
     {% set bindings = [] %}
 
@@ -7,17 +8,20 @@
     {% for chunk in agate_table.rows | batch(batch_size) %}
         {% set bindings = [] %}
 
+        {% for row in chunk %}
+            {% do bindings.extend(row) %}
+        {% endfor %}
+
         {% set sql %}
-            insert into {{ this.render() }} ({{ cols_sql }})
+            insert all
             {% for row in chunk -%}
-                select
-                {%- for column in agate_table.column_names -%}
-                    {{" '" + row[loop.index - 1] + "' " }}
+              into {{ this.render() }} ({{ cols_sql }}) values
+                ( {%- for column in agate_table.column_names -%}
+                    :p{{ loop.index }} 
                     {%- if not loop.last%},{%- endif %}
-                {%- endfor -%}
-                from dual {{" "}}
-                {%- if not loop.last%} union all {{" "}} {%- endif %}
+                {%- endfor %} )
             {%- endfor %}
+            select * from dual
         {% endset %}
 
         {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}
@@ -32,5 +36,6 @@
 {% endmacro %}
 
 {% macro oracle__load_csv_rows(model, agate_table) %}
-  {{ return(basic_load_csv_rows_oracle(model, 10000, agate_table) )}}
+  {{ return(oracle_basic_load_csv_rows(model, 50, agate_table) )}}
 {% endmacro %}
+

--- a/dbt/include/oracle/macros/schema_tests.sql
+++ b/dbt/include/oracle/macros/schema_tests.sql
@@ -36,8 +36,6 @@ from validation_errors
 
 {% endmacro %}
 
-
-
 {% macro oracle__test_not_null(model) %}
 
 {% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
@@ -47,3 +45,21 @@ from {{ model.include(False, True, True) }}
 where {{ column_name }} is null
 
 {% endmacro %}
+
+{% macro oracle__test_relationships(model, to, field) %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('from')) %}
+
+
+select count(*) as validation_errors
+from (
+    select {{ column_name }} as id from {{ model }}
+) child
+left join (
+    select {{ field }} as id from {{ to }}
+) parent on parent.id = child.id
+where child.id is not null
+  and parent.id is null
+
+{% endmacro %}
+

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'dbt': [
             'include/oracle/dbt_project.yml',
             'include/oracle/macros/*.sql',
-            'include/oracle/macros/materializations/seed/*.sql'
+            'include/oracle/macros/**/**/*.sql'
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-        'dbt-core==0.16.0',
+        'dbt-core==0.17.2',
         'cx_Oracle==7.3.0'
 ]
 


### PR DESCRIPTION
Hello, This PR contains : 

- a full implementation of adapters.sql and catalog.sql
- setup.py updated to match latest 0.17.2 release version

Now, documentation gets generated, and description ends up in db's comments !

Concerning custom schema tests, I already pushed a adapter like version, but we will have to wait for the next release in order to override default ones. For now, one has to copy the schema_test.sql file into the main project, and remove the "oracle__" prefix of the macro names.

I hope you will be able to test and give me feedback soon !

Thank you for initiating this work, as we are still a few to be stucked on oracle.