### PR TITLE
Fix list relations macro

### DIFF
--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -112,12 +112,12 @@
           numeric_precision as "numeric_precision",
           numeric_scale as "numeric_scale"
       from columns
-      where table_name = upper('{{ relation.identifier }}')
+      where upper(table_name) = upper('{{ relation.identifier }}')
         {% if relation.schema %}
-        and table_schema = upper('{{ relation.schema }}')
+        and upper(table_schema) = upper('{{ relation.schema }}')
         {% endif %}
         {% if relation.database %}
-        and table_catalog = upper('{{ relation.database }}')
+        and upper(table_catalog) = upper('{{ relation.database }}')
         {% endif %}
       order by ordinal_position
 
@@ -269,8 +269,8 @@
     end as "kind"
   from tables
   where table_type in ('BASE TABLE', 'VIEW')
-    and table_catalog = upper('{{ schema_relation.database }}')
-    and table_schema = upper('{{ schema_relation.schema }}')
+    and upper(table_catalog) = upper('{{ schema_relation.database }}')
+    and upper(table_schema) = upper('{{ schema_relation.schema }}')
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}


### PR DESCRIPTION
First of all, thanks for building this adapter - appreciate the hard work! I've made some changes that should make incremental loading work properly. The main problem was that `adapter.get_relation` wasn't returning any results, which I traced back to the `oracle__list_relations_without_caching` macro. 

The database and schema arguments were being changed to uppercase, but the output of `sys.all_tables` and `sys.all_views` was not. I've updated all comparisons in `adapters.sql` to use uppercase and the macros now provide usable output.

I haven't been able to run all tests yet because I'm having environment issues, but wanted to open a PR for feedback anyway.