### PR TITLE
Fix syntax error in snapshot.sql

### DIFF
--- a/dbt/include/oracle/macros/materializations/snapshot/snapshot.sql
+++ b/dbt/include/oracle/macros/materializations/snapshot/snapshot.sql
@@ -123,7 +123,7 @@
             snapshotted_data.dbt_scd_id
     
         from snapshotted_data
-        left join deletes_source_data as source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
+        left join deletes_source_data source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
         where source_data.dbt_unique_key is null
     )
     {%- endif %}


### PR DESCRIPTION
Thanks a lot for your work creating this adapter.
This fix is required to make the snapshot mechanismn working on Oracle. Oracle does not support the keyword "as" to define table aliases.