### PR TITLE
Add cleanup of staging table after snapshot

### DIFF
--- a/dbt/include/oracle/macros/materializations/snapshot/snapshot.sql
+++ b/dbt/include/oracle/macros/materializations/snapshot/snapshot.sql
@@ -289,3 +289,8 @@
     {%- set result = "TO_TIMESTAMP('"~ timestamp ~ "','yyyy/mm/dd hh24:mi:ss.FF')" -%}
     {{ return(result) }}
 {%- endmacro %}
+
+{% macro oracle__post_snapshot(staging_relation) %}
+  -- Clean up the snapshot temp table
+  {% do drop_relation(staging_relation) %}
+{% endmacro %}


### PR DESCRIPTION
Thanks a lot for your work creating this adapter.
This fix is required to make the snapshot mechanismn working on Oracle. The cleanup of staging tables was missing for oracle.